### PR TITLE
Removed oldpwd

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-OLDPWD=$( PWD )
 SCRIPTDIR=$( dirname $0 )
 cd ${SCRIPTDIR} || exit 1
 LOGSLIST=$( tr '\n' ',' < "${SCRIPTDIR}/config/logslist" )


### PR DESCRIPTION
**$OLDPWD** is an internal bash variable

```
$ info bash
...
'OLDPWD'
     The previous working directory as set by the 'cd' builtin.
...
```